### PR TITLE
Refactor: term history

### DIFF
--- a/backend/graphql/resolvers/TermResolver.ts
+++ b/backend/graphql/resolvers/TermResolver.ts
@@ -38,7 +38,7 @@ export class TermResolver {
       return resolveTermSaturation({ term, populate });
    }
 
-   @FieldResolver(() => [ReviewSessionEntry], { nullable: true })
+   @FieldResolver(() => [[ReviewSessionEntry]], { nullable: true })
    async history(
       @Root() term: Term,
       @Arg("populate", { nullable: true }) populate?: boolean

--- a/backend/graphql/resolvers/term/resolve-history.ts
+++ b/backend/graphql/resolvers/term/resolve-history.ts
@@ -13,7 +13,11 @@ type Args = {
 export async function resolveTermHistory({ term, populate, sql = instance }: Args) {
    if (!populate) return;
 
-   return sql<[ReviewSessionEntry]>`
-      select * from review_session_entries where term_id=${term.term_id}
-   `;
+   return (
+      await sql<[{ session: [ReviewSessionEntry] }]>`
+      select jsonb_agg(to_jsonb(r.*)) session from (
+         select e.*, extract(epoch from e.created_at) as created_at from review_session_entries e where term_id=${term.term_id}
+      ) r group by r.review_session_id
+   `
+   ).map((x) => x.session);
 }

--- a/backend/graphql/types/ReviewSessionEntry.ts
+++ b/backend/graphql/types/ReviewSessionEntry.ts
@@ -24,6 +24,6 @@ export class ReviewSessionEntry extends ReviewSessionEntryInput {
    @Field(() => Int)
    review_entry_id: number;
 
-   @Field(() => Int)
+   @Field()
    created_at: number;
 }

--- a/backend/schema.gql
+++ b/backend/schema.gql
@@ -80,7 +80,7 @@ type ReviewSession {
 }
 
 type ReviewSessionEntry {
-  created_at: Int!
+  created_at: Float!
   direction: String!
   passfail: String!
   review_entry_id: Int!
@@ -110,7 +110,7 @@ input ReviewSessionInput {
 type Term {
   from_language: String!
   from_value: String!
-  history(populate: Boolean): [ReviewSessionEntry!]
+  history(populate: Boolean): [[ReviewSessionEntry!]!]
   list_id: Int!
   saturation(populate: Boolean): TermSaturation
   term_id: Int!

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
 		"@babel/preset-env": "^7.15.8",
 		"@babel/preset-react": "^7.14.5",
 		"@babel/preset-typescript": "^7.15.0",
+		"@mdx-js/react": "^2.1.2",
 		"@storybook/addon-actions": "^6.5.9",
 		"@storybook/addon-essentials": "^6.5.9",
 		"@storybook/addon-interactions": "^6.5.9",

--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -23,7 +23,17 @@ const App = () => {
 	return (
 		<>
 			<QueryClientProvider client={client}>
-				<ReactQueryDevtools initialIsOpen={false} />
+				<ReactQueryDevtools
+					initialIsOpen={false}
+					panelProps={{
+						style: {
+							maxWidth: "40vw",
+							bottom: 0,
+							left: 0,
+						},
+					}}
+					position="bottom-right"
+				/>
 				<RecoilRoot>
 					<S.App>
 						<ThemeProvider theme={theme}>

--- a/frontend/src/components/list/hooks/useList.tsx
+++ b/frontend/src/components/list/hooks/useList.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useQueryListsById } from "gql/hooks/list/useQueryLists";
 import useRouteProps from "hooks/useRouteProps";
 import { useEffect } from "react";
+import { useQueryListsById } from "../../../gql/hooks/list/useQueryLists";
 
 function useList() {
 	const { params } = useRouteProps();

--- a/frontend/src/components/list/stories/ListDeleteButton.stories.tsx
+++ b/frontend/src/components/list/stories/ListDeleteButton.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import ListDeleteButton from "./ListDeleteButton";
+import ListDeleteButton from "../sub/ListDeleteButton";
 
 export default {
 	component: ListDeleteButton,

--- a/frontend/src/components/list/stories/ListReviewButtons.stories.tsx
+++ b/frontend/src/components/list/stories/ListReviewButtons.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import ListReviewButtons from "./ListReviewButtons";
+import ListReviewButtons from "../sub/ListReviewButtons";
 
 export default {
 	component: ListReviewButtons,

--- a/frontend/src/components/list/stories/ListTerm.stories.tsx
+++ b/frontend/src/components/list/stories/ListTerm.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { QueryClientProvider, useQueryClient } from "@tanstack/react-query";
 import { RecoilRoot } from "recoil";
 import { Term } from "../../../gql/codegen-output";
-import ListTerm from "./ListTerm";
+import ListTerm from "../sub/ListTerm";
 
 export default {
 	component: ListTerm,

--- a/frontend/src/components/list/stories/ListTitleBar.stories.tsx
+++ b/frontend/src/components/list/stories/ListTitleBar.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { List } from "../../../gql/codegen-output";
-import ListTitleBar from "./ListTitleBar";
+import ListTitleBar from "../sub/ListTitleBar";
 
 export default {
 	component: ListTitleBar,

--- a/frontend/src/components/list/stories/TermReviewHistory.stories.tsx
+++ b/frontend/src/components/list/stories/TermReviewHistory.stories.tsx
@@ -1,0 +1,63 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import styled from "styled-components";
+import TermReviewHistory from "../sub/TermReviewHistory";
+
+export default {
+	component: TermReviewHistory,
+	argTypes: {},
+} as ComponentMeta<typeof TermReviewHistory>;
+
+const Wrapper = styled.div`
+	max-width: 850px;
+	border: 2px solid orange;
+	padding: 1rem;
+`;
+
+const now = new Date().valueOf() / 1000;
+
+export const Basic: ComponentStory<typeof TermReviewHistory> = (props) => (
+	<Wrapper>
+		<TermReviewHistory
+			history={[
+				[
+					{
+						created_at: now,
+						direction: "forwards",
+						passfail: "pass",
+						review_entry_id: 1,
+						review_session_id: 2,
+						term_id: 1,
+						time_on_card: 100,
+					},
+					{
+						created_at: now,
+						direction: "forwards",
+						passfail: "fail",
+						review_entry_id: 1,
+						review_session_id: 2,
+						term_id: 1,
+						time_on_card: 100,
+					},
+					{
+						created_at: now,
+						direction: "forwards",
+						passfail: "pass",
+						review_entry_id: 1,
+						review_session_id: 2,
+						term_id: 1,
+						time_on_card: 100,
+					},
+					{
+						created_at: now,
+						direction: "forwards",
+						passfail: "pass",
+						review_entry_id: 1,
+						review_session_id: 2,
+						term_id: 1,
+						time_on_card: 100,
+					},
+				],
+			]}
+		/>
+	</Wrapper>
+);

--- a/frontend/src/components/list/sub/TermModal.style.tsx
+++ b/frontend/src/components/list/sub/TermModal.style.tsx
@@ -201,7 +201,7 @@ export const TermModal = styled.div`
 	color: white;
 	border: 2px solid #333;
 	box-shadow: 10px 10px 0 -2px #444;
-	width: 50%;
+	width: 40vw;
 	margin: 0 auto;
 	left: 25%;
 	overflow-y: auto;

--- a/frontend/src/components/list/sub/TermReviewHistory.style.tsx
+++ b/frontend/src/components/list/sub/TermReviewHistory.style.tsx
@@ -27,7 +27,7 @@ export const ExpandButton = styled.button`
 	color: ${(p) => p.theme.colors.light.white};
 	padding: 0.5rem;
 	margin: 0.5rem 0;
-	width: 100px;
+	width: 12rem;
 
 	transition: all 50ms ease;
 

--- a/frontend/src/components/list/sub/TermReviewHistory.tsx
+++ b/frontend/src/components/list/sub/TermReviewHistory.tsx
@@ -14,7 +14,7 @@ export default function TermReviewHistory({ history }: { history: Term["history"
 	const historyElements = [...history]
 		.reverse()
 		.map((session) => (
-			<HistoryElement entries={session} key={session[0].review_entry_id} />
+			<TermHistoryEntry entries={session} key={session[0].review_entry_id} />
 		));
 
 	return (
@@ -47,7 +47,7 @@ type HistoryElementProps = {
 	entries: Term["history"][number];
 };
 
-function HistoryElement({ entries }: HistoryElementProps) {
+function TermHistoryEntry({ entries }: HistoryElementProps) {
 	const firstEntry = entries[0];
 
 	return (

--- a/frontend/src/components/list/sub/TermReviewHistory.tsx
+++ b/frontend/src/components/list/sub/TermReviewHistory.tsx
@@ -1,7 +1,6 @@
 import dayjs from "dayjs";
 import { useState } from "react";
 import { BiArrowToLeft, BiArrowToRight } from "react-icons/bi";
-import { v4 as uuidv4 } from "uuid";
 import { ReviewSessionEntry } from "../../../gql/codegen-output";
 import { colors } from "../../../helpers/theme/colors";
 import { timeSince } from "../../../helpers/time";
@@ -14,10 +13,13 @@ export default function TermReviewHistory({
 	history: ReviewSessionEntry[];
 }) {
 	const [showAll, setShowAll] = useState(false);
+	const toggleShowAll = () => setShowAll((cur) => !cur);
 
 	const historyElements = [...history]
 		.reverse()
-		.map((element) => <HistoryElement historyEntry={element} key={uuidv4()} />);
+		.map((element) => (
+			<HistoryElement historyEntry={element} key={element.review_entry_id} />
+		));
 
 	return (
 		<>
@@ -27,12 +29,14 @@ export default function TermReviewHistory({
 						You've reviewed this term {historyElements.length} time
 						{historyElements.length === 1 ? "" : "s"}
 					</S.Description>
+
 					{historyElements.length > 1 && (
-						<S.ExpandButton onClick={() => setShowAll(!showAll)}>
-							{!showAll ? "Showing one" : "Showing all"}
+						<S.ExpandButton onClick={toggleShowAll}>
+							{showAll ? "Showing all sessions" : "Showing latest session"}
 						</S.ExpandButton>
 					)}
 				</S.Header>
+
 				{historyElements.length > 0 && (
 					<S.HistoryContent>
 						{showAll ? historyElements : historyElements[0]}
@@ -61,8 +65,7 @@ function HistoryElement({ historyEntry }: HistoryElementProps) {
 					) : (
 						<BiArrowToLeft
 							title="Reviewed back to front"
-							// TODO: add to green theme value
-							fill="limegreen"
+							fill="limegreen" // TODO: add to green theme value
 							size={18}
 						/>
 					)}
@@ -74,14 +77,11 @@ function HistoryElement({ historyEntry }: HistoryElementProps) {
 			</S.HistorySessionBlock>
 
 			<S.HistorySessionBlock>
-				<div key={uuidv4()}>
-					<PassfailIcon
-						key={`passfailicon-${historyEntry.review_entry_id}`}
-						passfail={historyEntry.passfail}
-						// TODO: temporarily force index=0 during refactor effort
-						index={0}
-					/>
-				</div>
+				<PassfailIcon
+					key={`passfailicon-${historyEntry.review_entry_id}`}
+					passfail={historyEntry.passfail}
+					index={0} // NOTE: temporarily forcing index=0 during refactor effort
+				/>
 			</S.HistorySessionBlock>
 		</S.HistorySession>
 	);

--- a/frontend/src/components/list/sub/TermReviewHistory.tsx
+++ b/frontend/src/components/list/sub/TermReviewHistory.tsx
@@ -1,24 +1,20 @@
 import dayjs from "dayjs";
 import { useState } from "react";
 import { BiArrowToLeft, BiArrowToRight } from "react-icons/bi";
-import { ReviewSessionEntry } from "../../../gql/codegen-output";
+import { Term } from "../../../gql/codegen-output";
 import { colors } from "../../../helpers/theme/colors";
 import { timeSince } from "../../../helpers/time";
 import PassfailIcon from "../../_shared/PassfailIcon";
 import * as S from "./TermReviewHistory.style";
 
-export default function TermReviewHistory({
-	history,
-}: {
-	history: ReviewSessionEntry[];
-}) {
+export default function TermReviewHistory({ history }: { history: Term["history"] }) {
 	const [showAll, setShowAll] = useState(false);
 	const toggleShowAll = () => setShowAll((cur) => !cur);
 
 	const historyElements = [...history]
 		.reverse()
-		.map((element) => (
-			<HistoryElement historyEntry={element} key={element.review_entry_id} />
+		.map((session) => (
+			<HistoryElement entries={session} key={session[0].review_entry_id} />
 		));
 
 	return (
@@ -48,15 +44,17 @@ export default function TermReviewHistory({
 }
 
 type HistoryElementProps = {
-	historyEntry: ReviewSessionEntry;
+	entries: Term["history"][number];
 };
 
-function HistoryElement({ historyEntry }: HistoryElementProps) {
+function HistoryElement({ entries }: HistoryElementProps) {
+	const firstEntry = entries[0];
+
 	return (
 		<S.HistorySession>
 			<S.HistorySessionBlock>
 				<S.Direction>
-					{historyEntry.direction === "forwards" ? (
+					{firstEntry.direction === "forwards" ? (
 						<BiArrowToRight
 							title="Reviewed front to back"
 							fill={colors.blue.main}
@@ -71,17 +69,19 @@ function HistoryElement({ historyEntry }: HistoryElementProps) {
 					)}
 				</S.Direction>
 
-				<span title={dayjs(historyEntry.created_at).format("MMMM DD, YYYY (HH:mm)")}>
-					{timeSince(historyEntry.created_at)}
+				<span title={dayjs(firstEntry.created_at).format("MMMM DD, YYYY (HH:mm)")}>
+					{timeSince(firstEntry.created_at * 1000)}
 				</span>
 			</S.HistorySessionBlock>
 
 			<S.HistorySessionBlock>
-				<PassfailIcon
-					key={`passfailicon-${historyEntry.review_entry_id}`}
-					passfail={historyEntry.passfail}
-					index={0} // NOTE: temporarily forcing index=0 during refactor effort
-				/>
+				{entries.map((entry) => (
+					<PassfailIcon
+						key={`passfailicon-${entry.review_entry_id}`}
+						passfail={entry.passfail}
+						index={entry.review_entry_id}
+					/>
+				))}
 			</S.HistorySessionBlock>
 		</S.HistorySession>
 	);

--- a/frontend/src/gql/codegen-output.ts
+++ b/frontend/src/gql/codegen-output.ts
@@ -110,7 +110,6 @@ export type MutationLoginArgs = {
 export type MutationUpdateListArgs = {
   list_id: Scalars['Float'];
   payload: ListUpdatePayloadInput;
-  user_id: Scalars['Float'];
 };
 
 
@@ -188,7 +187,7 @@ export type ReviewSession = {
 
 export type ReviewSessionEntry = {
   __typename?: 'ReviewSessionEntry';
-  created_at: Scalars['Int'];
+  created_at: Scalars['Float'];
   direction: Scalars['String'];
   passfail: Scalars['String'];
   review_entry_id: Scalars['Int'];
@@ -219,7 +218,7 @@ export type Term = {
   __typename?: 'Term';
   from_language: Scalars['String'];
   from_value: Scalars['String'];
-  history?: Maybe<Array<ReviewSessionEntry>>;
+  history?: Maybe<Array<Array<ReviewSessionEntry>>>;
   list_id: Scalars['Int'];
   saturation?: Maybe<TermSaturation>;
   term_id: Scalars['Int'];
@@ -452,7 +451,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   deleteUser?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   login?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationLoginArgs, 'password' | 'username'>>;
   logout?: Resolver<ResolversTypes['Message'], ParentType, ContextType>;
-  updateList?: Resolver<Maybe<ResolversTypes['List']>, ParentType, ContextType, RequireFields<MutationUpdateListArgs, 'list_id' | 'payload' | 'user_id'>>;
+  updateList?: Resolver<Maybe<ResolversTypes['List']>, ParentType, ContextType, RequireFields<MutationUpdateListArgs, 'list_id' | 'payload'>>;
   updateListLanguage?: Resolver<Maybe<ResolversTypes['List']>, ParentType, ContextType, RequireFields<MutationUpdateListLanguageArgs, 'payload'>>;
   updatePassword?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationUpdatePasswordArgs, 'currentPassword' | 'newPassword'>>;
   updateTermValues?: Resolver<Array<ResolversTypes['Term']>, ParentType, ContextType, RequireFields<MutationUpdateTermValuesArgs, 'updateOptions'>>;
@@ -483,7 +482,7 @@ export type ReviewSessionResolvers<ContextType = any, ParentType extends Resolve
 };
 
 export type ReviewSessionEntryResolvers<ContextType = any, ParentType extends ResolversParentTypes['ReviewSessionEntry'] = ResolversParentTypes['ReviewSessionEntry']> = {
-  created_at?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  created_at?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   direction?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   passfail?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   review_entry_id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -496,7 +495,7 @@ export type ReviewSessionEntryResolvers<ContextType = any, ParentType extends Re
 export type TermResolvers<ContextType = any, ParentType extends ResolversParentTypes['Term'] = ResolversParentTypes['Term']> = {
   from_language?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   from_value?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  history?: Resolver<Maybe<Array<ResolversTypes['ReviewSessionEntry']>>, ParentType, ContextType, RequireFields<TermHistoryArgs, never>>;
+  history?: Resolver<Maybe<Array<Array<ResolversTypes['ReviewSessionEntry']>>>, ParentType, ContextType, RequireFields<TermHistoryArgs, never>>;
   list_id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   saturation?: Resolver<Maybe<ResolversTypes['TermSaturation']>, ParentType, ContextType, RequireFields<TermSaturationArgs, never>>;
   term_id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;

--- a/frontend/src/gql/fragments/term-fragments.ts
+++ b/frontend/src/gql/fragments/term-fragments.ts
@@ -1,10 +1,32 @@
 import { gql } from "graphql-request";
 
+const termSaturationPropsFragment = gql`
+	fragment TermSaturationProps on TermSaturation {
+		backwards
+		forwards
+		last_updated
+		term_id
+	}
+`;
+
+const termHistoryPropsFragment = gql`
+	fragment TermHistoryProps on ReviewSessionEntry {
+		created_at
+		direction
+		passfail
+		review_entry_id
+		review_session_id
+		time_on_card
+	}
+`;
+
 /**
  * Most common term props.
  * @note term.history and term.saturation are not populated by default
  */
 export const termPropsFragment = gql`
+	${termSaturationPropsFragment}
+	${termHistoryPropsFragment}
 	fragment TermProps on Term {
 		list_id
 		term_id
@@ -12,5 +34,13 @@ export const termPropsFragment = gql`
 		to_language
 		to_value
 		from_value
+
+		saturation(populate: true) {
+			...TermSaturationProps
+		}
+
+		history(populate: true) {
+			...TermHistoryProps
+		}
 	}
 `;

--- a/frontend/src/gql/hooks/user/useQueryMe.ts
+++ b/frontend/src/gql/hooks/user/useQueryMe.ts
@@ -22,7 +22,6 @@ type Options = {
 export function useQueryMe(options: Options) {
 	return useQuery<User>(["me"], async () => queryMeRequest(), {
 		retry: false,
-		enabled: false,
 		onSuccess: (user) => options.onSuccess?.(user),
 	});
 }

--- a/frontend/src/helpers/list.api.ts
+++ b/frontend/src/helpers/list.api.ts
@@ -1,5 +1,3 @@
-import { Term } from "gql/codegen-output";
-
 type Direction = "forwards" | "backwards";
 
 /** Takes a list, returns all its sessions with the specified direction, and its
@@ -11,14 +9,6 @@ export const extractSessionsByDirection = (list, direction: Direction) => {
 		(sess) => sess.direction === direction
 	);
 	return [sessionsByDirection.length, sessionsByDirection];
-};
-
-/**
- * Extract all sessions with a given direction from a term's history
- * @param {Object} term
- */
-export const termSessionsByDirection = (term: Term, direction: Direction) => {
-	return term.history?.filter((session) => session?.direction === direction);
 };
 
 export const colorMap = {

--- a/frontend/src/hooks/useQueryClient.ts
+++ b/frontend/src/hooks/useQueryClient.ts
@@ -5,6 +5,7 @@ export default function useInitializeQueryClient() {
 		defaultOptions: {
 			queries: {
 				staleTime: 0,
+				refetchOnMount: true,
 				cacheTime: 5 * 60 * 1000, // 5 minutes
 				refetchOnWindowFocus: true,
 			},

--- a/frontend/src/hooks/useReconcileSession.ts
+++ b/frontend/src/hooks/useReconcileSession.ts
@@ -26,6 +26,8 @@ export default function useReconcileSession() {
 	});
 
 	useEffect(() => {
-		refetch();
-	}, []);
+		if (currentUser) {
+			refetch();
+		}
+	}, [currentUser]);
 }


### PR DESCRIPTION
# In this PR
- change Term.history FieldResolver and `resolveTermHistory` function to take a slightly different shape: this now returns `ReviewSessionEntry[][]`, like 
   ```typescript
  [
    [entry, entry, entry],
    [entry, entry]
  ]
   ```
  The entries here are grouped by `review_session_id`. meaning that each sublist represents one review session.
- rename component `HistoryElement->TermReviewHistory` and update its functionality to work with this reworked Term.history shape.
- tweak various bits of styling (`TermModal` width, 'showing one'/'showing all' button width, etc. Nothing major.
- fix: change `TermReviewSession.created_at` resolved type to be a Float since timestamps overflow the 32-bit Int type

## Miscallaneous changes
- update styling of react-query devtools panel
- set `refetchOnMount: true` by default for react-query
  - impact: previously, we set `enabled: false` for queries and fetched manually, typically on mount. Now, we don't have to manually fetch on mount, as long as we don't accidentally set `enabled: false` in the query hook.
- include the `mdx-js/react` package as a frontend dev dependency. Storybook seems to have some issues when paired with react 18, and manually installing this package seems to fix this.
- add graphql fragments for termSaturation and termHistory

# Branch
Like e.g. #15, this PR merges into `modernize/resolvers/client` (see #14) as part of a larger effort to update the client-side codebase to work with the reworked GraphQL types and resolvers. Since the application's lost most of its functionality as a result of e.g. #11, I feel it's best to keep merging these changes into that branch and merge it into dev/master once the application's fully functional again.