### PR TITLE
`Saturation`: update after review

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,36 @@ Project built for personal use, but also as portfolio project.
 ## Status
 
 Alpha stage. Imcomplete feature set. Currently transitioning to TypeScript and GraphQL.
+
+## Developing locally
+
+[WIP]
+
+### Environment variables
+
+Certain environment variables need to be present: - [TODO]
+
+### Re-generating graphql typescript types across the stack:
+
+Run the following command from the top-level directory (i.e. the directory this
+README exists in):
+
+```bash
+   npx graphql-codegen --watch './backend/schema.gql'
+```
+
+### Development scripts
+
+-  Containerized application:
+   ```
+      npm run dock
+   ```
+-  Storybook:
+   ```
+   cd frontend && npm run storybook
+   ```
+-  Run tests:
+   -  Backend:
+      ```
+      npm run test-back
+      ```

--- a/backend/graphql/resolvers/review-session/get-sessions.ts
+++ b/backend/graphql/resolvers/review-session/get-sessions.ts
@@ -1,0 +1,45 @@
+import { WithSQL } from "../../../custom_types/with-sql.types";
+import { sql as instance } from "../../../db/init";
+import { SessionEntriesWithMeta } from "../../../lib/saturation/saturation.types";
+import { ReviewSession } from "../../types/ReviewSession";
+
+/**
+ * For each of the termIds given, return the latest 3 review sessions. Returns
+ * an array where each row represents one session for one term. So to get
+ * meaningful results, this array still has to be filtered.
+ */
+// TODO: implement unit tests.
+export async function getLatestSessionsForTerms({
+   sql = instance,
+   termIds,
+   direction,
+}: WithSQL<{ termIds: number[]; direction: ReviewSession["direction"] }>) {
+   return await sql<SessionEntriesWithMeta[]>`
+   select review_session_id, sq.term_id, to_json(sat.*) saturation, session from  (
+      select row_number() over (
+         partition by term_id order by review_session_id desc
+      ), aggregated.*
+   
+      from (
+         select 
+            r.review_session_id, 
+            r.term_id, 
+            jsonb_agg(r.*) session
+
+         from (
+            select 
+               ee.*,
+               extract(epoch from created_at)*1000 created_at
+            from review_session_entries ee
+         ) r
+         
+         where r.term_id=any(${termIds}::numeric[]) 
+         and r.direction=${direction}
+         group by (r.term_id, r.review_session_id) 
+         order by r.term_id
+      ) aggregated
+   ) sq
+   left join term_saturation sat on sat.term_id = sq.term_id
+   where sq.row_number <= 3
+   `;
+}

--- a/backend/graphql/resolvers/term/update-saturation.ts
+++ b/backend/graphql/resolvers/term/update-saturation.ts
@@ -1,0 +1,39 @@
+import { sql as instance, SQL } from "../../../db/init";
+import { TermSaturation } from "../../types/Term";
+
+/** Update one or multiple term saturation values in the database. */
+// TODO: unit test this
+// TODO: make arguments an object to fit codebase conventions
+export async function updateTermSaturation(
+   update: Omit<TermSaturation, "last_updated">[],
+   sql: SQL = instance
+) {
+   // Pipeline all the updates so they go in one transaction.
+   return sql.begin((q) =>
+      update.map((u) => {
+         // Filter out null values, since we don't want to manually set
+         // saturation values to null. This makes sure objects like {forwards:
+         // null, backwards: 1} are filtered to {backwards: 1}}
+         const updateObj = Object.entries(u).reduce((acc, [k, v]) => {
+            if (typeof v === "number" /* accounts for term_id and saturation values */) {
+               acc[k] = v;
+            }
+
+            return acc;
+         }, {} as TermSaturation);
+
+         // Don't even send the update if neither forwards nor backwards saturation
+         // are specified.
+         if (["forwards", "backwards"].every((x) => typeof updateObj[x] !== "number")) {
+            return;
+         }
+
+         return q`
+            update term_saturation 
+            set ${q({ ...updateObj, last_updated: new Date() } as any)} 
+            where term_id=${u.term_id}
+            returning *
+         `;
+      })
+   );
+}

--- a/backend/graphql/types/Term.ts
+++ b/backend/graphql/types/Term.ts
@@ -50,10 +50,10 @@ export class TermSaturation {
    term_id: number;
 
    @Field(() => Int, { nullable: true })
-   forwards: number;
+   forwards?: number;
 
    @Field(() => Int, { nullable: true })
-   backwards: number;
+   backwards?: number;
 
    @Field()
    last_updated: number; // timestamp

--- a/backend/graphql/types/Term.ts
+++ b/backend/graphql/types/Term.ts
@@ -49,10 +49,10 @@ export class TermSaturation {
    @Field(() => Int)
    term_id: number;
 
-   @Field(() => Int)
+   @Field(() => Int, { nullable: true })
    forwards: number;
 
-   @Field(() => Int)
+   @Field(() => Int, { nullable: true })
    backwards: number;
 
    @Field()

--- a/backend/lib/saturation/saturate-after-session.ts
+++ b/backend/lib/saturation/saturate-after-session.ts
@@ -1,0 +1,57 @@
+import { sql as instance, SQL } from "../../db/init";
+import {
+   getLatestSessionsForTerms,
+   parseSessionEntriesWithMeta,
+} from "../../graphql/resolvers/review-session/get-sessions";
+import { saturateSeededTerm } from "./saturate-seeded";
+import { saturateUnseededTerm } from "./saturate-unseeded";
+
+/**
+ * - fetch 3 most recent sessions in `direction` for all termIds
+ * - parse each `session` from the above response to ParsedSession
+ * - compute new saturation level in `direction` for each of termIds
+ *
+ * @usage Intended to be called from within the `createSession` pipeline, this
+ * way we ensure that this correctly evaluates the latest review session.
+ */
+export async function getNewSaturationLevels(
+   termIds: number[],
+   direction: "forwards" | "backwards",
+   sql: SQL = instance
+) {
+   // get 3 latest sessions (in `direction`) for each term in term_ids
+   const latest = await getLatestSessionsForTerms({ sql, termIds, direction });
+
+   // map the session (= PassFail[]) of each item in `latest` to ParsedSession
+   const parsedLatest = latest.map((x) => parseSessionEntriesWithMeta(x));
+
+   // loop over all terms. filter parsedLatest by term and then determine the
+   // term's new saturation level
+   const saturationUpdate = termIds.map((term_id) => {
+      const [current, previous, secondToLast] = parsedLatest.filter(
+         (x) => x.term_id === term_id
+      );
+
+      // If term doesn't have saturation yet, but it's been reviewed 3 times,
+      // treat it as unseeded term and saturate.
+      if (typeof current?.saturation?.[direction] !== "number") {
+         if (secondToLast) {
+            return {
+               term_id,
+               [direction]: saturateUnseededTerm({ current }),
+            };
+         } else {
+            return;
+         }
+      }
+
+      // If term _does_ have a saturation level, treat it as a seeded term.
+      return saturateSeededTerm(direction, {
+         current,
+         previous,
+         secondToLast,
+      });
+   });
+
+   return saturationUpdate;
+}

--- a/backend/lib/saturation/saturate-seeded.test.ts
+++ b/backend/lib/saturation/saturate-seeded.test.ts
@@ -1,0 +1,76 @@
+import { seededSaturationDeltaOperators } from "./saturate-seeded";
+import { ParsedSessionWithMeta } from "./saturation.types";
+
+// TODO: create some more mock parsed sessions, e.g. 'flawless first', 'flawless
+// three', 'only failed first', 'failed multiple', 'failed once but later'
+
+const current: ParsedSessionWithMeta = {
+   term_id: 1,
+   review_session_id: 1,
+   saturation: { term_id: 1, last_updated: 0, forwards: 1, backwards: null },
+   session: {
+      failedFirst: true,
+      passCount: 1,
+      failCount: 1,
+      passfail: ["fail", "pass"],
+   },
+};
+
+describe("seeded operators", () => {
+   const inc = seededSaturationDeltaOperators.maybeIncrementSaturation;
+   const dec = seededSaturationDeltaOperators.maybeDecrementSaturation;
+
+   describe("from level 0", () => {
+      it("does not increment level 0 if user failed at least once", () => {
+         expect(inc(0, { current })).toBeFalsy();
+      });
+
+      it("does increment level 0 if user didn't fail", () => {
+         const result = inc(0, {
+            current: { ...current, session: { ...current.session, failCount: 0 } },
+         });
+         expect(result).toBe(true);
+      });
+   });
+
+   describe("from level 1", () => {
+      it("decrements if failed first try", () => {});
+      it("decrements if failed multiple times", () => {});
+
+      it("increments if didn't fail 3 sessions in a row", () => {});
+   });
+
+   describe("from level 2", () => {
+      it("increments", () => {});
+
+      it("decrements", () => {});
+   });
+
+   describe("from level 3", () => {
+      it("increments", () => {});
+
+      it("decrements", () => {});
+   });
+
+   describe("from level 4", () => {
+      it("never increments", () => {
+         expect(
+            inc(4, {
+               current: {
+                  ...current,
+                  session: {
+                     ...current.session,
+                     failedFirst: false,
+                     failCount: 0,
+                     passfail: ["pass"],
+                  },
+               },
+            })
+         ).toBeFalsy();
+      });
+
+      it("decrements", () => {
+         expect(dec(4, { current: { session: { failCount: 1 } } as any })).toBeTruthy();
+      });
+   });
+});

--- a/backend/lib/saturation/saturate-seeded.ts
+++ b/backend/lib/saturation/saturate-seeded.ts
@@ -1,0 +1,96 @@
+import type { RecentSessions, SaturationLevel } from "./saturation.types";
+
+/**
+ * - maybe{Decrement/Increment} take a saturation level and one or more of the
+ *    most recent review sessions for a term in a given direction, and check if the
+ *    increment/decrement condition is met.
+ * - saturateSeededTerm takes the most recent sessions for a term in a
+ *    direction, and the current saturation level, and returns the term_id and
+ *    the new saturation for the given direction. The new saturation is derived
+ *    the decrement/increment conditions, combined with pre-set saturation delta
+ *    (increment once = +1, decrement twice = -2, etc.)
+ */
+
+function maybeDecrementSaturationTwice(
+   currentSaturation: SaturationLevel,
+   { current }: RecentSessions
+) {
+   switch (currentSaturation) {
+      case 0:
+      case 1:
+         return false;
+      case 2:
+      case 3:
+      case 4:
+         return current.session.failCount > 1;
+      default:
+         return false;
+   }
+}
+
+function maybeDecrementSaturation(
+   currentSaturation: SaturationLevel,
+   { current }: RecentSessions
+) {
+   switch (currentSaturation) {
+      case 0:
+         return false;
+      case 1:
+         return current.session.failedFirst || current.session.failCount > 1;
+      case 2:
+         return !current.session.failedFirst && current.session.failCount === 1;
+      case 3:
+      case 4:
+         return current.session.failCount === 1;
+      default:
+         return false;
+   }
+}
+
+function maybeIncrementSaturation(
+   currentSaturation: SaturationLevel,
+   { current, previous, secondToLast }: RecentSessions
+) {
+   switch (currentSaturation) {
+      case 0:
+         return !current.session.failCount;
+      case 1:
+      case 3:
+         return [current, previous, secondToLast].every((x) => !x.session.failCount);
+      case 2:
+         return [current, previous].every((x) => !x.session.failCount);
+      default:
+         return false;
+   }
+}
+
+export function saturateSeededTerm(
+   direction: "forwards" | "backwards",
+   recentSessions: RecentSessions
+): { term_id: number; forwards?: number; backwards?: number } {
+   const currentSaturation = recentSessions.current.saturation?.[
+      direction
+   ] as SaturationLevel;
+
+   // If the following occurs, we should be in `saturateUnseededTerm` instead.
+   // TODO: trigger Sentry event.
+   if (!currentSaturation) return;
+
+   const delta =
+      (maybeIncrementSaturation(currentSaturation, recentSessions) && 1) ||
+      (maybeDecrementSaturation(currentSaturation, recentSessions) && -1) ||
+      (maybeDecrementSaturationTwice(currentSaturation, recentSessions) && -2) ||
+      0;
+
+   return {
+      term_id: recentSessions.current.term_id,
+      [direction]: currentSaturation + delta,
+   };
+}
+
+/** Export all operators for testing purposes. Should not be used outside of testing. */
+export const seededSaturationDeltaOperators = {
+   maybeIncrementSaturation,
+   maybeDecrementSaturation,
+   maybeDecrementSaturationTwice,
+};

--- a/backend/lib/saturation/saturate-unseeded.test.ts
+++ b/backend/lib/saturation/saturate-unseeded.test.ts
@@ -1,0 +1,37 @@
+import { saturateUnseededTerm } from "./saturate-unseeded";
+import { PassFail } from "./saturation.types";
+
+const shouldBe2 = {
+   current: {
+      review_session_id: 1,
+      saturation: { term_id: 1, last_updated: 0, backwards: null, forwards: null },
+      session: {
+         failedFirst: false,
+         passCount: 1,
+         failCount: 0,
+         passfail: ["pass"] as PassFail[],
+      },
+      term_id: 1,
+   },
+};
+
+const shouldBe1 = structuredClone(shouldBe2);
+shouldBe1.current.session.failCount = 1;
+
+const shouldBe0 = structuredClone(shouldBe2);
+shouldBe0.current.session.failCount = 2;
+
+const shouldBeUndefined = structuredClone(shouldBe2);
+shouldBeUndefined.current = null;
+
+describe("saturateUnseededTerm", () => {
+   it("returns undefined if no sessions provided", () => {
+      expect(saturateUnseededTerm(shouldBeUndefined)).toBeUndefined();
+   });
+
+   it("returns correct values", () => {
+      expect(saturateUnseededTerm(shouldBe2)).toEqual(2);
+      expect(saturateUnseededTerm(shouldBe1)).toEqual(1);
+      expect(saturateUnseededTerm(shouldBe0)).toEqual(0);
+   });
+});

--- a/backend/lib/saturation/saturate-unseeded.ts
+++ b/backend/lib/saturation/saturate-unseeded.ts
@@ -1,0 +1,19 @@
+import { ParsedSessionWithMeta } from "./saturation.types";
+
+/**
+ * Assign an unseeded term a new saturation level.
+ * @note Checking whether a term is seeded or unseeded, and whether an unseeded
+ * term is ready to be assigned a saturation level, is done in
+ * `getNewSaturationLevels()`
+ */
+export function saturateUnseededTerm({ current }: { current: ParsedSessionWithMeta }) {
+   if (!current?.session.passfail.length) {
+      // TODO: trigger Sentry event.
+      return;
+   }
+   const { failCount } = current?.session;
+
+   if (!failCount) return 2;
+   if (failCount > 1) return 0;
+   return 1;
+}

--- a/backend/lib/saturation/saturation.types.ts
+++ b/backend/lib/saturation/saturation.types.ts
@@ -25,6 +25,17 @@ export type ParsedSession = {
    passCount: number;
 };
 
+export type SessionEntriesWithMeta = {
+   term_id: number;
+   review_session_id: number;
+   saturation: TermSaturation;
+   session: ReviewSessionEntry[];
+};
+
+export type ParsedSessionWithMeta = Omit<SessionEntriesWithMeta, "session"> & {
+   session: ParsedSession;
+};
+
 enum RecentSessionIdentifier {
    CURRENT = "current",
    PREVIOUS = "previous",
@@ -32,7 +43,7 @@ enum RecentSessionIdentifier {
 }
 
 export type RecentSessions = {
-   [k in `${RecentSessionIdentifier}`]: ParsedSession;
+   [k in `${RecentSessionIdentifier}`]?: ParsedSessionWithMeta;
 };
 
 // TODO: should this be an ObjectType()?

--- a/backend/lib/saturation/saturation.types.ts
+++ b/backend/lib/saturation/saturation.types.ts
@@ -1,0 +1,43 @@
+/** Export a number of types related to saturation functionality. */
+
+import { ReviewSessionEntry } from "../../graphql/types/ReviewSessionEntry";
+import { Term, TermSaturation } from "../../graphql/types/Term";
+
+// TODO: put this somewhere else;
+export type SaturationLevel = 0 | 1 | 2 | 3 | 4;
+
+// TODO: put this and PassFail somewhere else
+enum PassFailEnum {
+   PASS = "pass",
+   FAIL = "fail",
+}
+
+export type PassFail = `${PassFailEnum}`;
+
+export type ParsedSession = {
+   /** PassFail values from the session. */
+   passfail: PassFail[];
+   /** Did the session start with a 'fail'?  */
+   failedFirst: boolean;
+   /** Number of fails in this session. */
+   failCount?: number;
+   /** Number of passes in this session. */
+   passCount: number;
+};
+
+enum RecentSessionIdentifier {
+   CURRENT = "current",
+   PREVIOUS = "previous",
+   SECONDTOLAST = "secondToLast",
+}
+
+export type RecentSessions = {
+   [k in `${RecentSessionIdentifier}`]: ParsedSession;
+};
+
+// TODO: should this be an ObjectType()?
+// TODO: put this in Term typegraphql type definition file
+export type TermWithResolvedFields = Term & {
+   history: ReviewSessionEntry[];
+   saturation: TermSaturation;
+};

--- a/backend/schema.gql
+++ b/backend/schema.gql
@@ -137,8 +137,8 @@ type TermIdWithEntries {
 }
 
 type TermSaturation {
-  backwards: Int!
-  forwards: Int!
+  backwards: Int
+  forwards: Int
   last_updated: Float!
   term_id: Int!
 }

--- a/docker/database-setup/04-create-term-saturation.sql
+++ b/docker/database-setup/04-create-term-saturation.sql
@@ -1,7 +1,7 @@
 create table term_saturation (
    term_id serial primary key not null,
-   forwards int not null,
-   backwards int not null,
+   forwards int,
+   backwards int,
    last_updated timestamp not null default now(),
 
    constraint fk_saturation_term_id

--- a/documentation/branch/review/saturation/update.md
+++ b/documentation/branch/review/saturation/update.md
@@ -1,0 +1,4 @@
+-  [ ] re-implement functionality to update term saturation on review session completion.
+-  [ ] there's something wrong with reviewSettings resetting on unmount, I think.
+       I just started a review soon after another one, and now I have two
+       session_entry created_at values that are the same.

--- a/documentation/saturation/progress.md
+++ b/documentation/saturation/progress.md
@@ -1,0 +1,52 @@
+As obvious from the name, spaced repetition places a lot of emphasis on the
+_spacing_. You don't have to review things you already know very well as often
+as things you don't know very well yet.
+
+This application works with a level-based system. Each Term is assigned a
+'saturation' level, which is a measure of how well the user knows the Term, and
+thus how often they should be reviewing it.
+
+After every review session, the saturation of a Term is re-assessed based on the
+user's performance in the _current_ session, but also on that of their previous
+few sessions.
+
+## Levels
+
+We use five `saturation` levels. In the codebase, a saturation level is mapped to the domain
+[0,4], with 0 loosely meaning 'very bad to no recollection', to 4 meaning
+'very good recollection'
+
+## Progression
+
+### Maximum change per review
+
+After a review, a saturation level can change, or remain the same. The level can
+increase at most by 1 level after a review, with the sole exception being a
+flawless 'seeding' progression (see `seeding.md`), where a term can jump from 0
+to 2 after the final seeding session. The level could also decrease, by at most
+2 levels, after a review.
+
+### Level-based progression conditions
+
+We use a relatively straightforward decision tree to determine what happens to a
+saturation level based on the current saturation level, the user's recollection
+in the latest session, and depending on the current level, also on the user's
+recollection from the, at most two, previous sessions.
+
+### Constraints on progression
+
+The emphasis on spacing is reinforced in the codebase. Reviewing a term too
+quickly (determined by its current level) will mean the review is not counted
+towards progression.
+
+#### Example of a negated session
+
+Say a term has current saturation `{forwards: 0, backwards: 0}`. This term should ideally
+be reviewed once a day in each direction (we should allow for some lenience, e.g. a review one evening
+and then the next afternoon should be fine). If the user reviews the term two
+hours after their last review, then we shouldn't count the review. Short-term
+recollection and long-term recollection are not the same.
+
+For the sake of simplicity, we won't consider different types of reviews
+differently when evaluating saturation updates. It's up to the user to decide
+which style of reviewing they prefer.

--- a/frontend/src/components/review/ReviewPage.tsx
+++ b/frontend/src/components/review/ReviewPage.tsx
@@ -1,66 +1,16 @@
-import { reviewStageState } from "components/review/state/review-atoms";
-import { useEffect, useMemo } from "react";
-import { useRecoilState, useRecoilValue, useResetRecoilState } from "recoil";
-import { ReviewParamsInput } from "../../gql/codegen-output";
-import useQueryTermsForReview from "../../gql/hooks/term/useQueryTermsForReview";
-import useRouteProps from "../../hooks/useRouteProps";
-import { makeReviewParams } from "./helpers/review-type";
-import { reviewSessionState } from "./state/review-session";
+import useReviewPage from "./hooks/useReviewPage";
 import PostReview from "./sub/PostReview";
 import PreReview from "./sub/PreReview";
 import Review from "./sub/Review";
 
 /** Renders PreReview, Review, or PostReview depending on `reviewStage`. */
 function ReviewPage() {
-	const reviewStage = useRecoilValue(reviewStageState);
-	const resetReviewStage = useResetRecoilState(reviewStageState);
-	const [reviewSession, setReviewSession] = useRecoilState(reviewSessionState);
-	const resetReviewSession = useResetRecoilState(reviewSessionState);
-	const { location, search, params } = useRouteProps();
-	const [reviewParams, idsField] = useMemo(() => {
-		const reviewParams = makeReviewParams(search, location, params);
-		const idsField = (
-			["list_ids", "term_ids", "set_ids"] as Array<keyof ReviewParamsInput>
-		).filter((field) => (reviewParams[field] as number[])?.length > 0)?.[0];
-
-		return [reviewParams, idsField] as const;
-	}, [location, search, params]);
-
-	const { data, refetch } = useQueryTermsForReview(reviewSession, reviewParams);
-
-	/* NOTE:
-      idsField depends on the URL, which is currently static through this
-      component's life, but it's conceivable that we might end up doing so one day.
-      In that case, consider introducing a `startedRef` or similar to track
-      whether the review has already started, and only setReviewSession if the
-      review hasn't started yet.  */
-	useEffect(() => {
-		setReviewSession((cur) => ({ ...cur, [idsField]: [+params.id] }));
-	}, [idsField]);
-
-	useEffect(() => {
-		/**
-		 * Refetch termsForReview whenever one of the required query variables (=
-		 * arguments of useQueryTermsForReview)
-		 * @note this logic can be improved. @see documentation/implementation/review/refetch-logic
-		 */
-		refetch();
-	}, [reviewSession.n, reviewParams]);
-
-	useEffect(() => {
-		resetReviewStage();
-
-		return () => {
-			resetReviewStage();
-			resetReviewSession();
-		};
-	}, []);
-
+	const { reviewStage, reviewParams, cardTerms } = useReviewPage();
 	switch (reviewStage) {
 		case "before":
 			return <PreReview initialSettings={reviewParams} />;
 		case "started":
-			return <Review cardTerms={data} />;
+			return <Review cardTerms={cardTerms} />;
 		case "after":
 			return <PostReview />;
 	}

--- a/frontend/src/components/review/helpers/ids-fields.ts
+++ b/frontend/src/components/review/helpers/ids-fields.ts
@@ -1,0 +1,5 @@
+import { ReviewParamsInput } from "../../../gql/codegen-output";
+
+export const idsFields = ["list_ids", "term_ids", "set_ids"] as Array<
+	keyof ReviewParamsInput
+>;

--- a/frontend/src/components/review/helpers/ids-fields.ts
+++ b/frontend/src/components/review/helpers/ids-fields.ts
@@ -1,5 +1,5 @@
 import { ReviewParamsInput } from "../../../gql/codegen-output";
 
-export const idsFields = ["list_ids", "term_ids", "set_ids"] as Array<
+export const idsFields = ["term_ids", "list_ids", "set_ids"] as Array<
 	keyof ReviewParamsInput
 >;

--- a/frontend/src/components/review/helpers/review-helpers.ts
+++ b/frontend/src/components/review/helpers/review-helpers.ts
@@ -78,6 +78,10 @@ export function entriesWithTimeOnCard(
 			time_on_card = entry.created_at - acc.at(-1).created_at;
 		}
 
+		if (time_on_card < 0)
+			throw new Error(
+				"Invalid time on card computed" + JSON.stringify({ start_date, time_on_card })
+			);
 		acc.push({ ...entry, time_on_card });
 
 		return acc;

--- a/frontend/src/components/review/helpers/review-type.ts
+++ b/frontend/src/components/review/helpers/review-type.ts
@@ -35,24 +35,31 @@ function getPageType({ pathname }: Location, params: Record<string, string>) {
 export function makeNaiveReviewParams(search: URLSearchParams) {
 	return Array.from(search.entries())
 		.filter(([k, v]) => allowedQueryParams.includes(k))
-		.reduce((acc, [k, v]: [k: keyof ReviewParamsInput, v: string]) => {
-			let newValue: number | number[];
+		.reduce(
+			(acc, [k, v]: [k: keyof ReviewParamsInput, v: string]) => {
+				let newValue: number | number[];
 
-			if (k.includes("_ids")) {
-				if (k in acc) {
-					newValue = (acc[k] as number[]).concat(+v); // can append to existing array
+				if (k.includes("_ids")) {
+					if (k in acc) {
+						newValue = (acc[k] as number[]).concat(+v); // can append to existing array
+					} else {
+						newValue = [+v]; // have to create array since we initialize as {}
+					}
 				} else {
-					newValue = [+v]; // have to create array since we initialize as {}
+					newValue = +v; // just a number
 				}
-			} else {
-				newValue = +v; // just a number
-			}
 
-			return {
-				...acc,
-				[k]: newValue,
-			};
-		}, {} as ReviewParamsInput);
+				return {
+					...acc,
+					[k]: newValue,
+				};
+			},
+			{
+				list_ids: [],
+				set_ids: [],
+				term_ids: [],
+			} as ReviewParamsInput
+		);
 }
 
 /**

--- a/frontend/src/components/review/helpers/review-type.ts
+++ b/frontend/src/components/review/helpers/review-type.ts
@@ -1,7 +1,6 @@
 import { Location } from "history";
 import { ReviewParamsInput } from "../../../gql/codegen-output";
-
-const allowedQueryParams = ["list_ids", "set_ids", "term_ids"];
+import { idsFields } from "./ids-fields";
 
 enum PageTypes {
 	LIST = "list",
@@ -34,11 +33,14 @@ function getPageType({ pathname }: Location, params: Record<string, string>) {
  */
 export function makeNaiveReviewParams(search: URLSearchParams) {
 	return Array.from(search.entries())
-		.filter(([k, v]) => allowedQueryParams.includes(k))
+		.filter(([k, v]) => idsFields.includes(k as any))
 		.reduce(
 			(acc, [k, v]: [k: keyof ReviewParamsInput, v: string]) => {
 				let newValue: number | number[];
 
+				// This if-else is a remnant from when there were non-*_ids fields
+				// in reviewParams, like min_saturation. Keep it here in case we end
+				// up extending reviewParams.
 				if (k.includes("_ids")) {
 					if (k in acc) {
 						newValue = (acc[k] as number[]).concat(+v); // can append to existing array

--- a/frontend/src/components/review/hooks/useReview.tsx
+++ b/frontend/src/components/review/hooks/useReview.tsx
@@ -37,8 +37,6 @@ export function useReview({ cardTerms }: UseReviewOptions) {
    */
 	const [remainingTerms, setRemainingTerms] = useState(cardTerms);
 
-	useEffect(() => {}, [remainingTerms]);
-
 	/**
 	 * Update all necessary state to move on to the next ReviewCard. This
 	 * function can either be called through a keydown event handler, or manually

--- a/frontend/src/components/review/hooks/useReviewPage.tsx
+++ b/frontend/src/components/review/hooks/useReviewPage.tsx
@@ -17,7 +17,7 @@ export default function useReviewPage() {
 
 	const [reviewParams, idsField] = useMemo(() => {
 		const reviewParams = makeReviewParams(search, location, params);
-		const idsField = idsFields.find((f) => reviewParams[f].length);
+		const idsField = idsFields.find((f) => reviewParams[f]?.length);
 
 		return [reviewParams, idsField] as const;
 	}, [location, search, params]);

--- a/frontend/src/components/review/hooks/useReviewPage.tsx
+++ b/frontend/src/components/review/hooks/useReviewPage.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useMemo } from "react";
+import { useRecoilState, useRecoilValue, useResetRecoilState } from "recoil";
+import useQueryTermsForReview from "../../../gql/hooks/term/useQueryTermsForReview";
+import useRouteProps from "../../../hooks/useRouteProps";
+import { idsFields } from "../helpers/ids-fields";
+import { makeReviewParams } from "../helpers/review-type";
+import { reviewStageState } from "../state/review-atoms";
+import { reviewSessionState } from "../state/review-session";
+
+export default function useReviewPage() {
+	const reviewStage = useRecoilValue(reviewStageState),
+		resetReviewStage = useResetRecoilState(reviewStageState),
+		[reviewSession, setReviewSession] = useRecoilState(reviewSessionState),
+		resetReviewSession = useResetRecoilState(reviewSessionState);
+
+	const { location, search, params } = useRouteProps();
+
+	const [reviewParams, idsField] = useMemo(() => {
+		const reviewParams = makeReviewParams(search, location, params);
+		const idsField = idsFields.find((f) => reviewParams[f].length);
+
+		return [reviewParams, idsField] as const;
+	}, [location, search, params]);
+
+	const { data: cardTerms, refetch } = useQueryTermsForReview(
+		reviewSession,
+		reviewParams
+	);
+
+	/* NOTE:
+      idsField depends on the URL, which is currently static through this
+      component's life, but it's conceivable that we might end up doing so one day.
+      In that case, consider introducing a `startedRef` or similar to track
+      whether the review has already started, and only setReviewSession if the
+      review hasn't started yet.  */
+	useEffect(() => {
+		setReviewSession((cur) => ({ ...cur, [idsField]: [+params.id] }));
+	}, [idsField]);
+
+	useEffect(() => {
+		/**
+		 * Refetch termsForReview whenever one of the required query variables (=
+		 * arguments of useQueryTermsForReview) changes.
+		 * @note this logic can be improved:
+		 *    @see documentation/implementation/review/refetch-logic.
+		 */
+		refetch();
+	}, [reviewSession.n, reviewParams]);
+
+	useEffect(() => {
+		resetReviewStage();
+
+		return () => {
+			resetReviewStage();
+			resetReviewSession();
+		};
+	}, []);
+
+	return {
+		reviewStage,
+		reviewParams,
+		cardTerms,
+	} as const;
+}

--- a/frontend/src/gql/codegen-output.ts
+++ b/frontend/src/gql/codegen-output.ts
@@ -263,8 +263,8 @@ export type TermIdWithEntries = {
 
 export type TermSaturation = {
   __typename?: 'TermSaturation';
-  backwards: Scalars['Int'];
-  forwards: Scalars['Int'];
+  backwards?: Maybe<Scalars['Int']>;
+  forwards?: Maybe<Scalars['Int']>;
   last_updated: Scalars['Float'];
   term_id: Scalars['Int'];
 };
@@ -541,8 +541,8 @@ export type TermIdWithEntriesResolvers<ContextType = any, ParentType extends Res
 };
 
 export type TermSaturationResolvers<ContextType = any, ParentType extends ResolversParentTypes['TermSaturation'] = ResolversParentTypes['TermSaturation']> = {
-  backwards?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  forwards?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  backwards?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  forwards?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   last_updated?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   term_id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;

--- a/frontend/src/helpers/srs/saturation.ts
+++ b/frontend/src/helpers/srs/saturation.ts
@@ -128,7 +128,7 @@ export function saturateSeededTerm(
 				}
 			case "2":
 				if (fail) {
-					if (fail > 2) return 0;
+					if (fail > 1) return 0;
 					return currentSession.content[0] === "pass" ? 2 : 1;
 				} else {
 					if (!previousFail) {


### PR DESCRIPTION
# Requirements
With the MongoDB implementation we computed new saturation levels in the client-side. We want to do this server-side now.

# Implementation
- [x] update TermSaturation (in the database, and thus also the typing client/server-side) to make `forwards` and `backwards` nullable
- [x] replace the client-side if/else behemoth with a combination of operator functions (`maybeIncrement`, `maybeDecrement`, `maybeDecrementTwice`)
- [x] implement a query that fetches the three latest sessions in a given `direction` for each of a given list of `termIds`
- [x] implement a function to parse the response of the above query to something from which we can determine new saturation levels
- [x] implement the UPDATE query that actually updates terms with the new saturation levels
- [ ] implement unit tests for all new functionality
  - a lot of mock objects are needed to properly unit test the results of these newly implement functions, which I'm putting off for a little bit 'cause it's mind-numbing work and I have more exciting things to work on. 😬 

# Branch
Merges into `refactor/review` because this is a core piece of functionality related to that refactor (also see #27)